### PR TITLE
Simplify grafana onboarding + "peer request --show-options"

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-collector.yml
+++ b/.github/ISSUE_TEMPLATE/new-collector.yml
@@ -1,6 +1,6 @@
 name: Host a New Collector (draft)
 description: Offer resources so Route Views can maintain a collector at your Internet Exchange (IX).
-title: "New Collector"
+title: New Collector
 labels: 
   - triage
   - collector

--- a/.github/ISSUE_TEMPLATE/onboarding.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding.yml
@@ -44,7 +44,7 @@ body:
         - label: Add to ["Route Views Maintainers" GitHub Team](https://github.com/orgs/routeviews/teams/maintainers/members?add=true).
         - label: Deploy public SSH Key to RV infrastructure (via Ansible). Follow the [New Route Views Maintainer workflow (TODO)](https://github.com/routeviews/infra/blob/master/docs/contribute/new_rv_maintainer.md).
         - label: Setup <username>@routeviews.org email account.
-        - label: Provide access to [our Grafana instance](http://rvmonitor.routeviews.org:3000/).
+        - label: Assign Admin access to [our Grafana instance](https://rvmonitor.routeviews.org:3000/).
         - label: Admit/ensure access to RV in PeeringDB.
         - label: Ensure access to RV Slack.
         - label: 'Provide access to the private Maintainer-only Slack channels. Today this includes: "peer requests" and "infrastructure".'
@@ -62,8 +62,15 @@ body:
         - label: Ensure access to [Route Views Slack](https://routeviewsworkspace.slack.com).
         - label: Review the [RV Maintainer Handbook (TODO update link to GH Pages)](https://github.com/routeviews/handbook).
         - label: Set up a PeeringDB account, and ['request Affiliation' with Route Views  (ASN 6447) on your PeeringDB profile page](https://www.peeringdb.com/profile).
-        - label: "[*Prereq: establish some tunnel via an RV jump host, then...*](https://github.com/routeviews/infra/issues/156#issuecomment-1248742381) Ensure login, and take a look through dashboards in [our Grafana instance](http://rvmonitor.routeviews.org:3000/)."
+        - label: Log into [RV Monitor, our Grafana instance](https://rvmonitor.routeviews.org:3000/).
         - label: Complete your first peer request! 😁 (with help from an existing maintainer)
+  - type: checkboxes
+    attributes:
+      label: Existing Maintainer Final Tasks
+      description: |
+        Onboarding tasks to be completed by an existing Route Views Maintainer. (within days of submission)
+      options:
+        - label: Assign "Editor" access in [RV Monitor (Grafana)](https://rvmonitor.routeviews.org:3000/).
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/onboarding.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding.yml
@@ -44,7 +44,6 @@ body:
         - label: Add to ["Route Views Maintainers" GitHub Team](https://github.com/orgs/routeviews/teams/maintainers/members?add=true).
         - label: Deploy public SSH Key to RV infrastructure (via Ansible). Follow the [New Route Views Maintainer workflow (TODO)](https://github.com/routeviews/infra/blob/master/docs/contribute/new_rv_maintainer.md).
         - label: Setup <username>@routeviews.org email account.
-        - label: Assign Admin access to [our Grafana instance](https://rvmonitor.routeviews.org:3000/).
         - label: Admit/ensure access to RV in PeeringDB.
         - label: Ensure access to RV Slack.
         - label: 'Provide access to the private Maintainer-only Slack channels. Today this includes: "peer requests" and "infrastructure".'

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -23,10 +23,16 @@ body:
     id: peeringdb_up_to_date
     attributes:
       label: PeeringDB Integration
-      description: >
-        Please ensure your PeeringDB entries are up to date before requesting
-        peering. We rely heavily on integrations with PeeringDB to reduce
-        overhead and improve operations.
+      description: |
+        Wanna see ***all available exchanges*** we can peer at according to PeeringDB?
+        Run our Python 3 utility to find out for yourself! 
+
+            pip install routeviews
+            routeviews-build-peer --asn <YOUR_ASN> --show-options
+
+        > ⚠ Please ensure your PeeringDB entries are up to date before requesting
+        > peering. We rely heavily on integrations with PeeringDB to reduce
+        > overhead and improve operations.
       options:
         - label: My PeeringDB Entries are current
           required: true

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -24,8 +24,7 @@ body:
     attributes:
       label: PeeringDB Integration
       description: |
-        Wanna see **ALL EXCHANGES** where we can peer? Try out the 
-        [`routeviews` Python Package](https://pypi.org/project/routeviews/)!
+        Wanna see **ALL EXCHANGES** where we can peer? Try out the [`routeviews` Python Package](https://pypi.org/project/routeviews/)!
 
             pip install routeviews
             routeviews-build-peer --asn <YOUR_ASN> --show-options

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -37,7 +37,7 @@ body:
     attributes:
       label: Peer Address(es)
       description: >
-        If not peering at all available exchanges, provide IP Addresses of the
+        If not peering at **ALL EXCHANGES**, provide IP Addresses of the
         devices you'd like to peer with Route Views.
         List multiple addresses seperated by whitespace characters (newlines, spaces, tabs, etc.)
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -24,15 +24,15 @@ body:
     attributes:
       label: PeeringDB Integration
       description: |
-        Wanna see ***all available exchanges*** we can peer with you according to PeeringDB?
-        Try out the [`routeviews` Python Package](https://pypi.org/project/routeviews/)!
+        Wanna see **ALL EXCHANGES** where we can peer? Try out the 
+        [`routeviews` Python Package](https://pypi.org/project/routeviews/)!
 
             pip install routeviews
             routeviews-build-peer --asn <YOUR_ASN> --show-options
       options:
         - label: My PeeringDB Entries are current
           required: true
-        - label: Peer at ***all available exchanges*** (*and skip the Peer Address(es) field below*)
+        - label: Peer at **ALL EXCHANGES** (*and skip the Peer Address(es) field below*)
   - type: textarea
     id: ipaddrs
     attributes:

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -24,15 +24,11 @@ body:
     attributes:
       label: PeeringDB Integration
       description: |
-        Wanna see ***all available exchanges*** we can peer at according to PeeringDB?
-        Run our Python 3 utility to find out for yourself! 
+        Wanna see ***all available exchanges*** we can peer with you according to PeeringDB?
+        Try out the [`routeviews` Python Package](https://pypi.org/project/routeviews/)!
 
             pip install routeviews
             routeviews-build-peer --asn <YOUR_ASN> --show-options
-
-        > ⚠ Please ensure your PeeringDB entries are up to date before requesting
-        > peering. We rely heavily on integrations with PeeringDB to reduce
-        > overhead and improve operations.
       options:
         - label: My PeeringDB Entries are current
           required: true

--- a/.github/ISSUE_TEMPLATE/peer-request.yml
+++ b/.github/ISSUE_TEMPLATE/peer-request.yml
@@ -46,9 +46,9 @@ body:
       label: Multihop
       description: >
         Is this a multihop peering session? If yes, make sure to set a nice 
-        long TTL for this session! (We use TTL of *255*)
+        long TTL for this session! (*We configure `TTL=255`*)
       options:
-        - label: Multihop
+        - label: Multihop Peering Request
   - type: checkboxes
     id: terms
     attributes:

--- a/docs/peer-request.md
+++ b/docs/peer-request.md
@@ -1,2 +1,0 @@
-TODO, make a 'peer request' form in github and provide a link here.
-TODO, consider if this is a good place for a small 'peer handbook'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,11 +6,10 @@ site_name: Route Views Wish List
 #
 nav:
   - README.md
+  - Voting Guide: voting.md
+  - New Collector Guide: new-collector.md
   - 🗳 Vote in GitHub: https://github.com/routeviews/issues/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc
   - 🎟️ Submit an Issue: https://github.com/routeviews/issues/issues/new/choose
-  - Voting Guide: voting.md
-  - Peer Request Guide: peer-request.md
-  - New Collector Guide: new-collector.md
 
 #
 # We use a specific "theme" (and more) to make the site pretty!


### PR DESCRIPTION
Reflect updates to [RV Monitor, our Grafana instance](https://rvmonitor.routeviews.org:3000/):

* now running HTTPs,
* without strict iptables restrictions, and
* uses GitHub for Authentication+Authorization!

